### PR TITLE
Catch and just log all errors

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,3 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec

--- a/lib/graphite-notify/capistrano.rb
+++ b/lib/graphite-notify/capistrano.rb
@@ -4,7 +4,7 @@ require 'uri'
 
 module Capistrano
   module Graphite
-    # Called when a Capistrano::Configuration.instance exists. Will define two tasks: 
+    # Called when a Capistrano::Configuration.instance exists. Will define two tasks:
     #   * graphite:notify_deploy to notify graphite that a deploy occured with the app, the user, the stage in tags and message
     #   * graphite:notify_restart to notify graphite that a rollback occured with the app, the user, the stage in tags and message
     # @param [Capistrano::Configuration] configuration the current capistrano configuration instance
@@ -19,33 +19,41 @@ module Capistrano
         namespace :graphite do
           desc 'notify graphite that a deployment occured'
           task :notify_deploy, :on_error => :continue do
-            uri = URI::parse(graphite_url)
-            http = Net::HTTP.new(uri.host, uri.port)
-            if uri.scheme == 'https'
-              http.use_ssl = true
-            end
-            http.start  do |http|
-              if respond_to?(:stage)
-                http.post(uri.path, "{\"what\": \"deploy #{application} in #{stage}\", \"tags\": \"#{application},#{stage},#{real_revision},deploy\", \"data\": \"#{local_user}\"}")
-              else
-                http.post(uri.path, "{\"what\": \"deploy #{application}\", \"tags\": \"#{application},#{real_revision},deploy\", \"data\": \"#{local_user}\"}")
+            begin
+              uri = URI::parse(graphite_url)
+              http = Net::HTTP.new(uri.host, uri.port)
+              if uri.scheme == 'https'
+                http.use_ssl = true
               end
+              http.start  do |http|
+                if respond_to?(:stage)
+                  http.post(uri.path, "{\"what\": \"deploy #{application} in #{stage}\", \"tags\": \"#{application},#{stage},#{real_revision},deploy\", \"data\": \"#{local_user}\"}")
+                else
+                  http.post(uri.path, "{\"what\": \"deploy #{application}\", \"tags\": \"#{application},#{real_revision},deploy\", \"data\": \"#{local_user}\"}")
+                end
+              end
+            rescue => e
+              puts "Could not notify graphite of new deployment due to #{e.message}\n#{e.backtrace.join("\n")}"
             end
           end
 
           desc 'notify graphite that a rollback occured'
           task :notify_rollback, :on_error => :continue do
-            uri = URI::parse(graphite_url)
-            http = Net::HTTP.new(uri.host, uri.port)
-            if uri.scheme == 'https'
-              http.use_ssl = true
-            end
-            http.start  do |http|
-              if respond_to?(:stage)
-                http.post(uri.path, "{\"what\": \"rollback #{application} in #{stage}\", \"tags\": \"#{application},#{stage},#{real_revision},rollback\", \"data\": \"#{local_user}\"}")
-              else
-                http.post(uri.path, "{\"what\": \"rollback #{application}\", \"tags\": \"#{application},#{real_revision},rollback\", \"data\": \"#{local_user}\"}")
+            begin
+              uri = URI::parse(graphite_url)
+              http = Net::HTTP.new(uri.host, uri.port)
+              if uri.scheme == 'https'
+                http.use_ssl = true
               end
+              http.start  do |http|
+                if respond_to?(:stage)
+                  http.post(uri.path, "{\"what\": \"rollback #{application} in #{stage}\", \"tags\": \"#{application},#{stage},#{real_revision},rollback\", \"data\": \"#{local_user}\"}")
+                else
+                  http.post(uri.path, "{\"what\": \"rollback #{application}\", \"tags\": \"#{application},#{real_revision},rollback\", \"data\": \"#{local_user}\"}")
+                end
+              end
+            rescue => e
+              puts "Could not notify graphite of deployment rollback due to #{e.message}\n#{e.backtrace.join("\n")}"
             end
           end
         end


### PR DESCRIPTION
- Fixes deployments failing if it raises Errno::EHOSTUNREACH
- Uses https to talk to rubygems.org instead of http
